### PR TITLE
using a fork of sifter without microtime dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "lodash": "^2.4.1",
-    "sifter": "^0.4.1"
+    "sifter": "stuartleigh/sifter.js"
   },
   "devDependencies": {
     "babel": "^5.2.16",


### PR DESCRIPTION
sifter.js has a dependancy on microtime.js which is broken in a number of environments. This fork removes the dependancy and I recommend using it until such time as sifter.js gets fixed.
